### PR TITLE
Extend unicode character range regex

### DIFF
--- a/__tests__/simple-markdown-test.js
+++ b/__tests__/simple-markdown-test.js
@@ -2390,6 +2390,14 @@ describe("simple markdown", function() {
                 { content: "hi  bye", type: "text" },
             ]);
         });
+
+        it("should parse unicode characters in a word", function() {
+            var parsed = inlineParse("string with parse öppurtunitiés");
+            validateParse(parsed, [{
+                type: "text",
+                content: "string with parse öppurtunitiés"
+            }]);
+        });
     });
 
     describe("preprocess step", function() {

--- a/simple-markdown.js
+++ b/simple-markdown.js
@@ -1289,7 +1289,7 @@ var defaultRules = {
         // We break on any symbol characters so that this grammar
         // is easy to extend without needing to modify this regex
         match: inlineRegex(
-            /^[\s\S]+?(?=[^0-9A-Za-z\s\u00C0-\u00FF]|\n\n| {2,}\n|\w+:\S|$)/
+            /^[\s\S]+?(?=[^0-9A-Za-z\s\u00c0-\uffff]|\n\n| {2,}\n|\w+:\S|$)/
         ),
         parse: function(capture, parse, state) {
             return {

--- a/simple-markdown.js
+++ b/simple-markdown.js
@@ -1289,7 +1289,7 @@ var defaultRules = {
         // We break on any symbol characters so that this grammar
         // is easy to extend without needing to modify this regex
         match: inlineRegex(
-            /^[\s\S]+?(?=[^0-9A-Za-z\s\u00ff-\uffff]|\n\n| {2,}\n|\w+:\S|$)/
+            /^[\s\S]+?(?=[^0-9A-Za-z\s\u00C0-\u00FF]|\n\n| {2,}\n|\w+:\S|$)/
         ),
         parse: function(capture, parse, state) {
             return {


### PR DESCRIPTION
With this commit characters from À to ÿ will be supported. Before this
commit words with f.e. an ö in it would be parsed as a seperate word.