### PR TITLE
Fix evil regex for `em`

### DIFF
--- a/simple-markdown.js
+++ b/simple-markdown.js
@@ -1189,7 +1189,7 @@ var defaultRules = {
             new RegExp(
                 // only match _s surrounding words.
                 "^\\b_" +
-                "((?:__|\\\\[\\s\\S]|[^\\_])+?)_" +
+                "((?:__|\\\\_|[^\\_])+?)_" +
                 "\\b" +
                 // Or match *s:
                 "|" +


### PR DESCRIPTION
Using the following input it is possible to have the RegExp do such a computationally expensive task that it effectively freezes the JS thread.

`_______SSSSS__H______HS______M__M_M__M____A___A______S_______H______H`