### PR TITLE
Blockquotes: Break blockquotes after two blank lines

### DIFF
--- a/__tests__/simple-markdown-test.js
+++ b/__tests__/simple-markdown-test.js
@@ -1552,6 +1552,44 @@ describe("simple markdown", function() {
             ]);
         });
 
+        it("should allow blockquotes to continue over one but not two blank lines", function() {
+            var parsed = blockParse(
+                "> blockquote 1\n\n" +
+                "> blockquote 1 continued\n\n\n" +
+                ">blockquote 2\n\n"
+            );
+            validateParse(parsed, [
+                {
+                    type: "blockQuote",
+                    content: [
+                        {
+                            type: "paragraph",
+                            content: [{
+                                type: "text",
+                                content: "blockquote 1"
+                            }],
+                        },
+                        {
+                            type: "paragraph",
+                            content: [{
+                                type: "text",
+                                content: "blockquote 1 continued"
+                            }],
+                        }
+                    ]
+                },
+                {
+                    type: "blockQuote",
+                    content: [{
+                        type: "paragraph",
+                        content: [{
+                            type: "text",
+                            content: "blockquote 2"
+                        }],
+                    }],
+                },
+            ]);
+        });
         it("should not let a > escape a paragraph as a blockquote", function() {
             var parsed = blockParse(
                 "para 1 > not a quote\n\n"

--- a/simple-markdown.js
+++ b/simple-markdown.js
@@ -654,7 +654,7 @@ var defaultRules = {
         }
     },
     blockQuote: {
-        match: blockRegex(/^( *>[^\n]+(\n[^\n]+)*\n*)+\n{2,}/),
+        match: blockRegex(/^( *>[^\n]+(\n[^\n]+)*\n{0,2})+\n{2,}/),
         parse: function(capture, parse, state) {
             var content = capture[0].replace(/^ *> ?/gm, '');
             return {


### PR DESCRIPTION
This isn't what commonmark or markdown do, so the best thing to
do seems a bit ambiguous. Open to suggestions, but this should
at least allow people to write multiple blockquotes when that's
what they want.

Test plan:
1. stash simple-markdown.js changes
2. run tests
3. see failure
4. unstash simple-markdown.js changes
5. run tests
6. see success

Tagging @xymostech 
