### PR TITLE
Better strong/em precedence

### DIFF
--- a/__tests__/simple-markdown-test.js
+++ b/__tests__/simple-markdown-test.js
@@ -171,9 +171,9 @@ describe("simple markdown", function() {
         it("should parse nested bold/italics", function() {
             var parsed = inlineParse("***hi***");
             validateParse(parsed, [{
-                type: "em",
+                type: "strong",
                 content: [{
-                    type: "strong",
+                    type: "em",
                     content: [{
                         type: "text",
                         content: "hi"
@@ -185,9 +185,9 @@ describe("simple markdown", function() {
         it("should parse nested bold/italics/underline", function() {
             var parsed1 = inlineParse("***__hi__***");
             validateParse(parsed1, [{
-                type: "em",
+                type: "strong",
                 content: [{
-                    type: "strong",
+                    type: "em",
                     content: [{
                         type: "u",
                         content: [{
@@ -215,9 +215,9 @@ describe("simple markdown", function() {
 
             var parsed3 = inlineParse("***bolditalics***");
             validateParse(parsed3, [{
-                type: "em",
+                type: "strong",
                 content: [{
-                    type: "strong",
+                    type: "em",
                     content: [{
                         type: "text",
                         content: "bolditalics",
@@ -330,6 +330,36 @@ describe("simple markdown", function() {
                     content: [{
                         type: "text",
                         content: "there you",
+                    }]
+                }]
+            }]);
+
+            var parsed3 = inlineParse("***like* this**");
+            validateParse(parsed3, [{
+                type: "strong",
+                content: [{
+                    type: "em",
+                    content: [{
+                        type: "text",
+                        content: "like",
+                    }]
+                }, {
+                    type: "text",
+                    content: " this",
+                }]
+            }]);
+
+            var parsed4 = inlineParse("**bold *and italics***");
+            validateParse(parsed4, [{
+                type: "strong",
+                content: [{
+                    type: "text",
+                    content: "bold ",
+                }, {
+                    type: "em",
+                    content: [{
+                        type: "text",
+                        content: "and italics",
                     }]
                 }]
             }]);
@@ -3001,7 +3031,7 @@ describe("simple markdown", function() {
         it("should output simple combined bold/italics", function() {
             assertParsesToReact(
                 "***bolditalics***",
-                '<em><strong>bolditalics</strong></em>'
+                '<strong><em>bolditalics</em></strong>'
             );
             assertParsesToReact(
                 "**bold *italics***",
@@ -3345,7 +3375,7 @@ describe("simple markdown", function() {
         it("should output simple combined bold/italics", function() {
             assertParsesToHtml(
                 "***bolditalics***",
-                '<em><strong>bolditalics</strong></em>'
+                '<strong><em>bolditalics</em></strong>'
             );
             assertParsesToHtml(
                 "**bold *italics***",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simple-markdown",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Javascript markdown parsing, made simple",
   "main": "simple-markdown.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simple-markdown",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Javascript markdown parsing, made simple",
   "main": "simple-markdown.js",
   "scripts": {


### PR DESCRIPTION
Parser: Make rules at the same order compete with each other

This solves the em/strong interaction problem in a more general way,
allowing us to have, in general, rules that have the same tokens, and
have their precedence resolved by whichever creates the larger match,
instead of requiring a forced precedence between them.
