### PR TITLE
Update React element creation to be faster (probably)

### DIFF
--- a/__tests__/simple-markdown-test.js
+++ b/__tests__/simple-markdown-test.js
@@ -43,7 +43,7 @@ var validateParse = function(parsed, expected) {
 var htmlThroughReact = function(parsed) {
     var output = defaultOutput(parsed);
     var rawHtml = ReactDOMServer.renderToStaticMarkup(
-        React.DOM.div(null, output)
+        React.createElement('div', null, output)
     );
     var innerHtml = rawHtml
         .replace(/^<div>/, '')


### PR DESCRIPTION
- Remove `_store` and update order of object keys to always match the order used by React itself (https://github.com/facebook/react/blob/v16.0.0-rc.2/src/isomorphic/classic/element/ReactElement.js#L123) and by babel-plugin-transform-react-inline-elements (https://github.com/babel/babel/blob/v6.26.0/packages/babel-helpers/src/helpers.js#L51)
- Switch to a function making the objects at a single callsite which should have a lower parse cost and be better for hidden-class-ness in engine optimizations (the reason React.createElement itself is slow-ish is that it loops over the props and copies them to a new object, which we avoid here)
- Require that the key is already a string or null (which React expects) and add casts in `reactFor` and list/table output to cast ints to strings explicitly (casting to string could also be done inside reactElement)