### PR TITLE
Bugfix: Render last table cell as empty table cell if it has no content

### DIFF
--- a/simple-markdown.js
+++ b/simple-markdown.js
@@ -503,7 +503,7 @@ var TABLES = (function() {
 
     var parseTableCells = function(capture, parse, state) {
         var rowsText = capture[3]
-            .replace(TABLE_CELLS_TRIM, "")
+            .replace(TABLE_CELLS_TRIM, "|")
             .split("\n");
 
         return rowsText.map(function(rowText) {


### PR DESCRIPTION
Hello! I noticed that the table rule has a small issue where if the contents of your last table cell is empty, it fails to render the cell at all. I believe it's because the `TABLE_CELLS_TRIM` regex turns this -> `| foo | |\n` into this -> `"| foo |"`, so when we split the cells by looking for `|`, it doesn't find the last cell and causes our missing cell issue.

This updates the `rowsText` variable in `parseTableCells` to this:
```javascript
var rowsText = capture[3]
    .replace(TABLE_CELLS_TRIM, "|")
    .split("\n");
```
where we now replace the `TABLE_CELLS_TRIM` with `|`, so that this -> `| foo | |\n` becomes this -> `"| foo | |"`, which keeps our last empty cell there.

------
**Example**

Text:
```
| Foo | Bar | Baz |
|-----|-----|-----|
| 123 | 234 | 456 |
| 123 | 234 |     |
```

Current output:
<img width="165" alt="screenshot 2017-10-16 13 14 26" src="https://user-images.githubusercontent.com/3639170/31628864-8750b384-b277-11e7-8642-895d71baed11.png">


With this PR:
<img width="162" alt="screenshot 2017-10-16 13 16 44" src="https://user-images.githubusercontent.com/3639170/31628879-90344ad8-b277-11e7-8dc3-138eb637efe7.png">
