### PR TITLE
Fix tests in React 16

### DIFF
--- a/__tests__/simple-markdown-test.js
+++ b/__tests__/simple-markdown-test.js
@@ -10,6 +10,8 @@ var implicitParse = SimpleMarkdown.defaultImplicitParse;
 var defaultOutput = SimpleMarkdown.defaultOutput;
 var defaultHtmlOutput = SimpleMarkdown.defaultHtmlOutput;
 
+var Div = React.createFactory('div');
+
 // A pretty-printer that handles `undefined` and functions better
 // than JSON.stringify
 // Important because some AST node fields can be undefined, and
@@ -43,7 +45,7 @@ var validateParse = function(parsed, expected) {
 var htmlThroughReact = function(parsed) {
     var output = defaultOutput(parsed);
     var rawHtml = ReactDOMServer.renderToStaticMarkup(
-        React.DOM.div(null, output)
+        Div(null, output)
     );
     var innerHtml = rawHtml
         .replace(/^<div>/, '')
@@ -3050,15 +3052,15 @@ describe("simple markdown", function() {
                 "\n",
                 '<table><thead>' +
                 '<tr>' +
-                '<th style="text-align:left;" scope="col">h1</th>' +
-                '<th style="text-align:center;" scope="col">h2</th>' +
-                '<th style="text-align:right;" scope="col">h3</th>' +
+                '<th style="text-align:left" scope="col">h1</th>' +
+                '<th style="text-align:center" scope="col">h2</th>' +
+                '<th style="text-align:right" scope="col">h3</th>' +
                 '</tr>' +
                 '</thead><tbody>' +
                 '<tr>' +
-                '<td style="text-align:left;">d1</td>' +
-                '<td style="text-align:center;">d2</td>' +
-                '<td style="text-align:right;">d3</td>' +
+                '<td style="text-align:left">d1</td>' +
+                '<td style="text-align:center">d2</td>' +
+                '<td style="text-align:right">d3</td>' +
                 '</tr>' +
                 '</tbody></table>'
             );

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
   "homepage": "https://github.com/Khan/simple-markdown",
   "devDependencies": {
     "mocha": "^2.5.3",
-    "react": ">=15.1.0",
-    "react-dom": ">=15.1.0",
+    "react": "^16.1.0",
+    "react-dom": "^16.1.0",
     "uglify-js": "^2.6.2",
     "underscore": "^1.8.3"
   }


### PR DESCRIPTION
Tests in master were broken on a fresh install (that would use React 16).

1. Replace deprecated div factory.
2. Update tables output.
3. Lock React to ^16 to prevent this kind of issues in the future.