### PR TITLE
Add size-limit

### DIFF
--- a/__tests__/simple-markdown-test.js
+++ b/__tests__/simple-markdown-test.js
@@ -10,6 +10,8 @@ var implicitParse = SimpleMarkdown.defaultImplicitParse;
 var defaultOutput = SimpleMarkdown.defaultOutput;
 var defaultHtmlOutput = SimpleMarkdown.defaultHtmlOutput;
 
+var Div = React.createFactory('div');
+
 // A pretty-printer that handles `undefined` and functions better
 // than JSON.stringify
 // Important because some AST node fields can be undefined, and
@@ -43,7 +45,7 @@ var validateParse = function(parsed, expected) {
 var htmlThroughReact = function(parsed) {
     var output = defaultOutput(parsed);
     var rawHtml = ReactDOMServer.renderToStaticMarkup(
-        React.DOM.div(null, output)
+        Div(null, output)
     );
     var innerHtml = rawHtml
         .replace(/^<div>/, '')
@@ -3050,15 +3052,15 @@ describe("simple markdown", function() {
                 "\n",
                 '<table><thead>' +
                 '<tr>' +
-                '<th style="text-align:left;" scope="col">h1</th>' +
-                '<th style="text-align:center;" scope="col">h2</th>' +
-                '<th style="text-align:right;" scope="col">h3</th>' +
+                '<th style="text-align:left" scope="col">h1</th>' +
+                '<th style="text-align:center" scope="col">h2</th>' +
+                '<th style="text-align:right" scope="col">h3</th>' +
                 '</tr>' +
                 '</thead><tbody>' +
                 '<tr>' +
-                '<td style="text-align:left;">d1</td>' +
-                '<td style="text-align:center;">d2</td>' +
-                '<td style="text-align:right;">d3</td>' +
+                '<td style="text-align:left">d1</td>' +
+                '<td style="text-align:center">d2</td>' +
+                '<td style="text-align:right">d3</td>' +
                 '</tr>' +
                 '</tbody></table>'
             );

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
   "homepage": "https://github.com/Khan/simple-markdown",
   "devDependencies": {
     "mocha": "^2.5.3",
-    "react": ">=15.1.0",
-    "react-dom": ">=15.1.0",
+    "react": "^16.1.0",
+    "react-dom": "^16.1.0",
     "uglify-js": "^2.6.2",
     "underscore": "^1.8.3"
   }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Javascript markdown parsing, made simple",
   "main": "simple-markdown.js",
   "scripts": {
-    "test": "make test"
+    "test": "make test && size-limit",
+    "size": "size-limit"
   },
   "repository": {
     "type": "git",
@@ -29,7 +30,14 @@
     "mocha": "^2.5.3",
     "react": "^16.1.0",
     "react-dom": "^16.1.0",
+    "size-limit": "^0.13.1",
     "uglify-js": "^2.6.2",
     "underscore": "^1.8.3"
-  }
+  },
+  "size-limit": [
+    {
+      "path": "simple-markdown.js",
+      "limit": "4 KB"
+    }
+  ]
 }


### PR DESCRIPTION
1. Will fail the CI if the library grows too big.
2. Run npm run size -- --why to run Webpack Bundle Analyzer.

Worth adding some kind of a size badge to the Readme — this library is 10 times smaller then most alternatives.

P. S. Depends on #38 to fix tests.