### PR TITLE
Added data: and vbscript: link fix to prevent XSS vulnerability

### DIFF
--- a/__tests__/simple-markdown-test.js
+++ b/__tests__/simple-markdown-test.js
@@ -3341,6 +3341,34 @@ describe("simple markdown", function() {
                 html2,
                 "<div class=\"paragraph\"><a>link</a></div>"
             );
+
+            var html3 = htmlFromReactMarkdown(
+                "[link](data:text/html;base64,PHNjcmlwdD5hbGVydCgnaGknKTwvc2NyaXB0Pg==)"
+            );
+            assert.strictEqual(html3, "<a>link</a>");
+
+            var html4 = htmlFromReactMarkdown(
+                "[link][1]\n\n" +
+                "[1]: data:text/html;base64,PHNjcmlwdD5hbGVydCgnaGknKTwvc2NyaXB0Pg==\n\n"
+            );
+            assert.strictEqual(
+                html4,
+                "<div class=\"paragraph\"><a>link</a></div>"
+            );
+
+            var html5 = htmlFromReactMarkdown(
+                "[link](vbscript:alert)"
+            );
+            assert.strictEqual(html5, "<a>link</a>");
+
+            var html6 = htmlFromReactMarkdown(
+                "[link][1]\n\n" +
+                "[1]: vbscript:alert\n\n"
+            );
+            assert.strictEqual(
+                html6,
+                "<div class=\"paragraph\"><a>link</a></div>"
+            );
         });
 
         it("should not sanitize safe links", function() {
@@ -3709,6 +3737,32 @@ describe("simple markdown", function() {
                 "[1]: javascript:alert('hi');\n\n";
             assertParsesToHtml(
                 markdown2,
+                "<div class=\"paragraph\"><a>link</a></div>"
+            );
+
+            var markdown3 = "[link](data:text/html;base64,PHNjcmlwdD5hbGVydCgnaGknKTwvc2NyaXB0Pg==)";
+            assertParsesToHtml(
+                markdown3,
+                "<a>link</a>"
+            );
+
+            var markdown4 = "[link][1]\n\n" +
+                "[1]: data:text/html;base64,PHNjcmlwdD5hbGVydCgnaGknKTwvc2NyaXB0Pg==\n\n";
+            assertParsesToHtml(
+                markdown4,
+                "<div class=\"paragraph\"><a>link</a></div>"
+            );
+
+            var markdown5 = "[link](vbscript:alert)";
+            assertParsesToHtml(
+                markdown5,
+                "<a>link</a>"
+            );
+
+            var markdown6 = "[link][1]\n\n" +
+                "[1]: vbscript:alert\n\n";
+            assertParsesToHtml(
+                markdown6,
                 "<div class=\"paragraph\"><a>link</a></div>"
             );
         });

--- a/simple-markdown.js
+++ b/simple-markdown.js
@@ -561,7 +561,7 @@ var sanitizeUrl = function(url /* : ?string */) {
         var prot = decodeURIComponent(url)
             .replace(/[^A-Za-z0-9/:]/g, '')
             .toLowerCase();
-        if (prot.indexOf('javascript:') === 0) {
+        if (prot.indexOf('javascript:') === 0 || prot.indexOf('vbscript:') === 0 || prot.indexOf('data:') === 0) {
             return null;
         }
     } catch (e) {


### PR DESCRIPTION
Cross-site Scripting (XSS) via Data or Vbscript URIs.
The following markup `[link](data:text/html;base64,PHNjcmlwdD5hbGVydCgnaGknKTwvc2NyaXB0Pg==)` produces `<script>alert('hi')</script>`.