### PR TITLE
inlineCode: fix overzealous replacement

### DIFF
--- a/simple-markdown.js
+++ b/simple-markdown.js
@@ -640,7 +640,7 @@ var LIST_ITEM_R = new RegExp(
     "gm"
 );
 var BLOCK_END_R = /\n{2,}$/;
-var INLINE_CODE_ESCAPE_BACKTICKS_R = /^ ( *` *) $|^ ( *`)|(` *) $/g;
+var INLINE_CODE_ESCAPE_BACKTICKS_R = /^ (?= *`)|(` *) $/g;
 // recognize the end of a paragraph block inside a list item:
 // two or more newlines at end end of the item
 var LIST_BLOCK_END_R = BLOCK_END_R;


### PR DESCRIPTION
$1 only refers to the parens in the first branch of the `` /^ ( *` *) $|^ ( *`)|(` *) $/g `` disjunction. If another branch matches, the replacement will be blank.

Sample input: ``​`​`​ ​a​`​ ​ ​`​`​``
Expected output: ``​ a` ​``
Actual output: `​ a`

Hex dumps, for copypasting (the above are full of U+200B ZERO WIDTH SPACE, to make GitHub's markdown parser render it properly):
Input: 60 60 20 61 60 20 20 60 60
Expected: 20 61 60 20
Actual: 20 61

Alternative fix: On line 1588, replace this regex with "$1$2$3".

See also #71.