### PR TITLE
Fix ReDoS with autolink

### DIFF
--- a/simple-markdown.js
+++ b/simple-markdown.js
@@ -1316,7 +1316,7 @@ var defaultRules /* : DefaultRules */ = {
     },
     autolink: {
         order: currOrder++,
-        match: inlineRegex(/^<([^ >]+:\/[^ >]+)>/),
+        match: inlineRegex(/^<([^: >]+:\/[^ >]+)>/),
         parse: function(capture, parse, state) {
             return {
                 type: "link",


### PR DESCRIPTION
Patterns like <<<<<<<<<<:/:/:/:/:/:/:/:/:/:/ currently exhibit O(n^3) complexity, allowing a 5KB document to take 7174ms to parse. With this change, it drops to O(n^2) and 73ms.

Tested with
```
<script src="simple-markdown.min.js"></script>
<script>
var str = "<".repeat(2000)+":/".repeat(1500);
var t1 = performance.now();
SimpleMarkdown.defaultInlineParse(str);
var t2 = performance.now();
document.write(str.length+" bytes, "+(t2-t1)+"ms");
</script>
```

This PR will change parsing of weird things like `<foo:bar:/baz>`. If you'd prefer leaving behavior 100% unchanged, the regex can instead be changed to `/^<(?=[^ >]+:\/)([^ >]+)>/`, with no meaningful performance difference.

What is the project policy for what counts as a DoS? Quadratic complexity is fine, anything higher is a bug? More than 1ms per byte on a 10KB document is a bug? Anything superlinear is a bug? If the latter, I can name a few other inputs with quadratic runtime.