### PR TITLE
sanitizeUrl: don't use decodeURIComponent

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -593,17 +593,14 @@ var sanitizeUrl = function(url /* : ?string */) {
     if (url == null) {
         return null;
     }
-    try {
-        var prot = decodeURIComponent(url)
-            .replace(/[^A-Za-z0-9/:]/g, '')
-            .toLowerCase();
+    try {   
+        var prot = new URL(url).protocol
         if (prot.indexOf('javascript:') === 0 || prot.indexOf('vbscript:') === 0 || prot.indexOf('data:') === 0) {
             return null;
         }
     } catch (e) {
-        // decodeURIComponent sometimes throws a URIError
-        // See `decodeURIComponent('a%AFc');`
-        // http://stackoverflow.com/questions/9064536/javascript-decodeuricomponent-malformed-uri-exception
+        // invalid URLs should throw a TypeError
+        // see for instance: `new URL("");`
         return null;
     }
     return url;

--- a/src/index.js
+++ b/src/index.js
@@ -594,7 +594,7 @@ var sanitizeUrl = function(url /* : ?string */) {
         return null;
     }
     try {   
-        var prot = new URL(url).protocol
+        var prot = new URL(url, 'https://localhost').protocol
         if (prot.indexOf('javascript:') === 0 || prot.indexOf('vbscript:') === 0 || prot.indexOf('data:') === 0) {
             return null;
         }


### PR DESCRIPTION
`decodeURIComponent` assumes input from `encodeURIComponent`. Importantly, this means that percent-encoded octets are assumed to always be UTF-8, but this is incorrect and can lead to valid URLs returning `null` from `sanitizeUrl`.

Here is a sample URL for which this happens: https://seesaawiki.jp/w/radioi_34/d/%a4%a2%b9%d4

`new URL("https://seesaawiki.jp/w/radioi_34/d/%a4%a2%b9%d4").protocol` returns `"https:"`, but `decodeURIComponent("https://seesaawiki.jp/w/radioi_34/d/%a4%a2%b9%d4")` throws a `URIError`.